### PR TITLE
After File Save As old version is saved

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -10,7 +10,7 @@ The MD can plan in advance the order of performance; later, `eMDee` will facilit
 Additional controls may be added to specific tracks such as changing the volume level.
 """
 
-version = "0.2.1" # TODO Update for each release
+version = "0.2.2" # TODO Update for each release
 
 authors = ["Stephen Merrony"]
 maintainers = ["Stephen Merrony <merrony@gmail.com>"]

--- a/src/gui-menu.adb
+++ b/src/gui-menu.adb
@@ -48,6 +48,7 @@ package body GUI.Menu is
       Prev_MIDI_Port : constant Unbounded_String := Sess.MIDI_Port;
    begin
       Clear_Session;
+      Main_Window.Set_Title (App_Title & " - (No session loaded)");
       Session_Desc_Entry.Set_Text ("");
       Session_Comment_Entry.Set_Text ("");
       Sess.MIDI_Port := Prev_MIDI_Port;
@@ -78,6 +79,7 @@ package body GUI.Menu is
             Display_Tracks;
          end if;
          GUI.Resize_Font (Font_Size'Value (To_String (Sess.Font_Size)));
+         Main_Window.Set_Title (App_Title & " - " & Filename);
       end if;
    exception
       when E : others =>
@@ -120,6 +122,7 @@ package body GUI.Menu is
          else
             Save_Session (To_String (Sess.Filename));
          end if;
+         Main_Window.Set_Title (App_Title & " - " & To_String (Sess.Filename));
       end if;
    end Session_Save_CB;
 
@@ -127,6 +130,7 @@ package body GUI.Menu is
       pragma Unreferenced (Self);
    begin
       Session_Save_As;
+      Main_Window.Set_Title (App_Title & " - " & To_String (Sess.Filename));
    end Session_Save_As_CB;
 
    procedure Session_Audio_CB (Self : access Gtk.Menu_Item.Gtk_Menu_Item_Record'Class) is

--- a/src/gui.adb
+++ b/src/gui.adb
@@ -231,7 +231,7 @@ package body GUI is
       Error : aliased GError;
    begin
       Main_Window := Gtk_Application_Window_New (App);
-      Main_Window.Set_Title (App_Title);
+      Main_Window.Set_Title (App_Title & " - (No session loaded)");
 
       if not CSS_Provider.Load_From_Data (Build_CSS (M), Error'Access) then
          Ada.Text_IO.Put_Line ("ERROR: Could not load CSS internal data");

--- a/src/gui.ads
+++ b/src/gui.ads
@@ -22,7 +22,7 @@ package GUI is
 
    package SB_Timeout_P is new Glib.Main.Generic_Sources (Gtk.Box.Gtk_Box);
 
-   App_SemVer    : constant String := "0.2.1";  --  TODO Update Version each release!
+   App_SemVer    : constant String := "0.2.2";  --  TODO Update Version each release!
    App_Title     : constant String := "eMDee";
    App_ID        : constant String := "fr.merrony." & App_Title;
    App_Comment   : constant String := "Musical Director's Assistant";

--- a/src/session.adb
+++ b/src/session.adb
@@ -131,6 +131,7 @@ package body Session is
 
       TOML.File_IO.Dump_To_File (Toml_Sess, File);
       Ada.Text_IO.Close (File);
+      Sess.Filename := To_Unbounded_String (Filename);
       Set_Clean;
    end Save_Session;
 


### PR DESCRIPTION
Update internal seesion filename when it changes.
Display current session filename in the main window tiutle.
Fixes #3